### PR TITLE
之前一直在用 windows,刚在 Mac 试了一下,用 webbrowser.open()函数是不会自动打开图片的,我改成 webbro…

### DIFF
--- a/src/login.py
+++ b/src/login.py
@@ -87,18 +87,21 @@ class Login():
         content = Http.get_content('https://www.zhihu.com/captcha.gif')  # 开始拉取验证码
         captcha_path = Path.base_path + u'/我是登陆知乎时的验证码.gif'
 
+
         with open(captcha_path, 'wb') as image:
             image.write(content)
         print u'请输入您所看到的验证码'
         print u'验证码在助手所处的文件夹中'
         print u'验证码位置:'
         print captcha_path
+        # import sys
         if platform.system() == "Darwin":
-            os.system("open %s &" % captcha_path)
-        elif platform.system() in ["SunOS", "FreeBSD", "Unix", "OpenBSD", "NetBSD", "Windows"]:
-            webbrowser.get().open_new_tab(u'file:///' + captcha_path)
+            # os.system("chmod 755 '%s' " % captcha_path)
+            # os.system(u'"{}"'.format(captcha_path).encode(sys.stdout.encoding))
+            os.system("open '%s' &" % captcha_path)
         else:
-            print(u"无法检测你的作业系统,请自行打开验证码 %s 文件,输入验证码" % captcha_path)
+            webbrowser.get().open_new_tab(u'file:///' + captcha_path)
+
         print u'如果不需要输入验证码可点按回车跳过此步'
         captcha = raw_input()
         return captcha

--- a/src/login.py
+++ b/src/login.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import cookielib
 import os
+import platform
 import webbrowser
 import json
 import urllib2
@@ -92,7 +93,12 @@ class Login():
         print u'验证码在助手所处的文件夹中'
         print u'验证码位置:'
         print captcha_path
-        webbrowser.open_new_tab(u'file:///' + captcha_path)
+        if platform.system() == "Darwin":
+            os.system("open %s &" % captcha_path)
+        elif platform.system() in ["SunOS", "FreeBSD", "Unix", "OpenBSD", "NetBSD", "Windows"]:
+            webbrowser.get().open_new_tab(u'file:///' + captcha_path)
+        else:
+            print(u"无法检测你的作业系统,请自行打开验证码 %s 文件,输入验证码" % captcha_path)
         print u'如果不需要输入验证码可点按回车跳过此步'
         captcha = raw_input()
         return captcha

--- a/src/login.py
+++ b/src/login.py
@@ -96,8 +96,7 @@ class Login():
         print captcha_path
         import sys
         if platform.system() == "Darwin":
-            os.system(u'"{}"'.format(captcha_path).encode(sys.stdout.encoding))
-            os.system("open '%s' &" % captcha_path)
+            os.system(u'open "{}" &'.format(captcha_path).encode(sys.stdout.encoding))
         else:
             webbrowser.get().open_new_tab(u'file:///' + captcha_path)
 

--- a/src/login.py
+++ b/src/login.py
@@ -96,7 +96,6 @@ class Login():
         print captcha_path
         import sys
         if platform.system() == "Darwin":
-            os.system("chmod 755 '%s' " % captcha_path)
             os.system(u'"{}"'.format(captcha_path).encode(sys.stdout.encoding))
             os.system("open '%s' &" % captcha_path)
         else:

--- a/src/login.py
+++ b/src/login.py
@@ -94,10 +94,10 @@ class Login():
         print u'验证码在助手所处的文件夹中'
         print u'验证码位置:'
         print captcha_path
-        # import sys
+        import sys
         if platform.system() == "Darwin":
-            # os.system("chmod 755 '%s' " % captcha_path)
-            # os.system(u'"{}"'.format(captcha_path).encode(sys.stdout.encoding))
+            os.system("chmod 755 '%s' " % captcha_path)
+            os.system(u'"{}"'.format(captcha_path).encode(sys.stdout.encoding))
             os.system("open '%s' &" % captcha_path)
         else:
             webbrowser.get().open_new_tab(u'file:///' + captcha_path)

--- a/src/login.py
+++ b/src/login.py
@@ -92,7 +92,7 @@ class Login():
         print u'验证码在助手所处的文件夹中'
         print u'验证码位置:'
         print captcha_path
-        webbrowser.open(u'file:///' + captcha_path)
+        webbrowser.open_new_tab(u'file:///' + captcha_path)
         print u'如果不需要输入验证码可点按回车跳过此步'
         captcha = raw_input()
         return captcha


### PR DESCRIPTION
…wser.open_new_tab 之后,会自动打开,但是是后台打开的,不会自动跳转到 firefox浏览器,我觉得这样对 Mac 用户不太友好啊,我的想法是按平台分开,windows 就用浏览器打开,其他平台用图片预览器打开,你觉得怎么样?