### PR TITLE
fix: 图片质量后缀需匹配多个字符替换

### DIFF
--- a/src/command/generate/base.ts
+++ b/src/command/generate/base.ts
@@ -235,8 +235,8 @@ class FetchBase extends Base {
         }
         let backupImgSrc = imgSrc
         // 去掉最后的_r/_b后缀
-        let imgSrc_raw = _.replace(imgSrc, /_\w/g, '_r')
-        let imgSrc_hd = _.replace(imgSrc, /_\w/g, '_b')
+        let imgSrc_raw = _.replace(imgSrc, /_\w*/g, '_r')
+        let imgSrc_hd = _.replace(imgSrc, /_\w*/g, '_b')
         // 彻底去除imgContent中的src属性
         imgContent = _.replace(imgContent, / src=".+?"/g, '  ')
         if (isLatexImg) {


### PR DESCRIPTION
原版本实际测试时url中在后缀后面多了一个b，匹配多个字符替换后缀后才是正确地址