### PR TITLE
Fix collection api

### DIFF
--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -29,9 +29,9 @@ class Collection extends Base {
     const baseUrl = `https://api.zhihu.com/collections/${collectionId}`
     const config = {
     }
-    const collectionInfoRecord: TypeCollection.Info = await Base.http.get(baseUrl, {
+    const collectionInfoRecord: TypeCollection.Info = (await Base.http.get(baseUrl, {
       params: config
-    })
+    })).collection
     return collectionInfoRecord
   }
 }


### PR DESCRIPTION
Collection API response now looks like:
```
{
    "collection": {
        "id": 20077047,
        "type": "collection",
        "title": "互联网技术",
        "is_public": true,
        "url": "https://api.zhihu.com/collections/20077047",
        "description": "",
        "follower_count": 0,
        "answer_count": 30,
        "item_count": 30,
        "like_count": 0,
        "view_count": 12,
        "comment_count": 0,
        "is_following": false,
        "is_liking": false,
        "created_time": 1367413158,
        "updated_time": 1570678850,
        "creator": {
            "id": "4d01ab470b548f8b893fba2d59b6113b",
            "type": "people",
            "is_following": false,
            "avatar_url": "https://pic4.zhimg.com/50/426044173285d5616455e97ead9bea86_l.jpg?source=0df5f383",
            "headline": "飞冰（ICE）",
            "user_type": "people",
            "gender": 1,
            "url": "https://api.zhihu.com/people/4d01ab470b548f8b893fba2d59b6113b",
            "name": "果大",
            "is_followed": false,
            "badge": []
        }
    },
    "status": 200,
    "message": ""
}
```
So a quick fix is submitted in this PR.