### PR TITLE
Fix pic suffix

### DIFF
--- a/src/command/generate/base.ts
+++ b/src/command/generate/base.ts
@@ -234,9 +234,9 @@ class FetchBase extends Base {
           imgSrc = _.get(matchImgSrc, [0], '')
         }
         let backupImgSrc = imgSrc
-        // 去掉最后的_r/_b后缀
-        let imgSrc_raw = _.replace(imgSrc, /_\w/g, '_r')
-        let imgSrc_hd = _.replace(imgSrc, /_\w/g, '_b')
+        // 去掉最后的_r/_b/_hd后缀
+        let imgSrc_raw = _.replace(imgSrc, /_\w{1,2}/g, '_r')
+        let imgSrc_hd = _.replace(imgSrc, /_\w{1,2}/g, '_b')
         // 彻底去除imgContent中的src属性
         imgContent = _.replace(imgContent, / src=".+?"/g, '  ')
         if (isLatexImg) {


### PR DESCRIPTION
It's possible that the basename of picture URL ends with "hd", so the regex's need update.

https://pic4.zhimg.com/50/2c0d070a29a7075035950f2446c80a37_hd.jpg